### PR TITLE
refactor: replace glob lib with node:fs/promises version

### DIFF
--- a/libs/ng-icons-manager/package.json
+++ b/libs/ng-icons-manager/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "chokidar": "5.0.0",
-    "glob": "13.0.6",
     "tslib": "^2"
   },
   "publishConfig": {

--- a/libs/ng-icons-manager/src/internal/core/icon-manager.ts
+++ b/libs/ng-icons-manager/src/internal/core/icon-manager.ts
@@ -31,7 +31,7 @@ export class IconManager {
     if (inputIssues.length > 0) return result(job.name, 0, inputIssues);
 
     const outputDirs = Object.values(this.config.jobs).map(({ outputDir }) => outputDir);
-    const scan = this.scanner.scan(job, outputDirs);
+    const scan = await this.scanner.scan(job, outputDirs);
     const resolution = await this.resolver.resolve(scan.icons, job.packagePreferences);
     const issues: JobIssue[] = [...scan.issues, ...resolution.issues];
 

--- a/libs/ng-icons-manager/src/internal/core/icon-scanner.ts
+++ b/libs/ng-icons-manager/src/internal/core/icon-scanner.ts
@@ -16,8 +16,8 @@ export class IconScanner {
     private readonly parser: IconParser,
   ) {}
 
-  scan(job: ResolvedJobConfig, outputDirs: string[]): ScanResult {
-    const { files, issues } = this.files(job, outputDirs);
+  async scan(job: ResolvedJobConfig, outputDirs: string[]): Promise<ScanResult> {
+    const { files, issues } = await this.files(job, outputDirs);
     const icons = new Set<string>();
 
     for (const file of files) {
@@ -31,7 +31,7 @@ export class IconScanner {
     return { icons, issues };
   }
 
-  private files(job: ResolvedJobConfig, outputDirs: string[]): { files: Set<string>; issues: ReadIssue[] } {
+  private async files(job: ResolvedJobConfig, outputDirs: string[]): Promise<{ files: Set<string>; issues: ReadIssue[] }> {
     const files = new Set<string>();
     const issues: ReadIssue[] = [];
     for (const inputDir of job.inputDirs) {
@@ -40,7 +40,9 @@ export class IconScanner {
         .filter((path) => path.length > 0 && path !== '..' && !path.startsWith(`..${sep}`))
         .map((path) => `${path.split(sep).join('/')}/**`);
       try {
-        this.fs.glob(job.include, { cwd: inputDir, ignore: [...job.exclude, ...ignoredOutputs] }).forEach((file) => files.add(file));
+        (await this.fs.glob(job.include, { cwd: inputDir, ignore: [...job.exclude, ...ignoredOutputs] })).forEach((file) =>
+          files.add(file),
+        );
       } catch (error) {
         issues.push({ kind: 'read', path: inputDir, message: `Failed to scan ${inputDir}: ${errorMessage(error)}` });
       }

--- a/libs/ng-icons-manager/src/internal/core/ports.ts
+++ b/libs/ng-icons-manager/src/internal/core/ports.ts
@@ -18,7 +18,7 @@ export interface FileSystem {
   readDirectory(path: string): DirectoryEntry[];
   createDirectory(path: string): void;
   remove(path: string): void;
-  glob(patterns: string[], options: GlobOptions): string[];
+  glob(patterns: string[], options: GlobOptions): Promise<string[]>;
 }
 
 export interface ModuleLoader {

--- a/libs/ng-icons-manager/src/internal/infrastructure/node-file-system.ts
+++ b/libs/ng-icons-manager/src/internal/infrastructure/node-file-system.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
-
-import { glob } from 'glob';
+import { glob } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
 import type { DirectoryEntry, FileSystem, GlobOptions } from '../core/ports';
 
@@ -41,14 +41,15 @@ export class NodeFileSystem implements FileSystem {
     rmSync(path, { recursive: true, force: true });
   }
 
-  glob(patterns: string[], options: GlobOptions): string[] {
-    return glob.sync(patterns, {
-      absolute: true,
+  async glob(patterns: string[], options: GlobOptions): Promise<string[]> {
+    const files: string[] = [];
+    for await (const file of glob(patterns, {
       cwd: options.cwd,
-      dot: false,
-      follow: false,
-      ignore: options.ignore,
-      nodir: true,
-    });
+      exclude: options.ignore,
+    })) {
+      if (this.isDirectory(resolve(options.cwd, file))) continue;
+      files.push(resolve(options.cwd, file));
+    }
+    return files;
   }
 }

--- a/libs/ng-icons-manager/src/test/fakes.ts
+++ b/libs/ng-icons-manager/src/test/fakes.ts
@@ -77,7 +77,7 @@ export class FakeFileSystem implements FileSystem {
     for (const directory of this.directories) if (directory.startsWith(prefix)) this.directories.delete(directory);
   }
 
-  glob(patterns: string[], options: GlobOptions): string[] {
+  async glob(patterns: string[], options: GlobOptions): Promise<string[]> {
     this.globCalls.push({ patterns, options });
     const error = this.globErrors.get(options.cwd);
     if (error) throw error;

--- a/libs/ng-icons-manager/src/test/scanner-and-runner.spec.ts
+++ b/libs/ng-icons-manager/src/test/scanner-and-runner.spec.ts
@@ -51,12 +51,12 @@ describe('icon scanner', () => {
     job = resolvedJob(source, output);
   });
 
-  it('passes job globs and every nested output exclusion to the filesystem port', () => {
+  it('passes job globs and every nested output exclusion to the filesystem port', async () => {
     const app = join(source, 'app.html');
     fs.writeFile(app, '<ng-icon name="bootstrapAlarm" />');
     fs.globResults.set(source, [app]);
 
-    const result = new IconScanner(fs, new IconParser()).scan(job, [output, join(root, 'other/icons')]);
+    const result = await new IconScanner(fs, new IconParser()).scan(job, [output, join(root, 'other/icons')]);
 
     expect([...result.icons]).toEqual(['bootstrapAlarm']);
     expect(fs.globCalls).toEqual([
@@ -67,22 +67,22 @@ describe('icon scanner', () => {
     ]);
   });
 
-  it('skips symbolic links and returns typed read issues', () => {
+  it('skips symbolic links and returns typed read issues', async () => {
     const linked = join(source, 'linked.html');
     const missing = join(source, 'missing.html');
     fs.symlinks.add(linked);
     fs.globResults.set(source, [linked, missing]);
 
-    const result = new IconScanner(fs, new IconParser()).scan(job, []);
+    const result = await new IconScanner(fs, new IconParser()).scan(job, []);
 
     expect(result.icons.size).toBe(0);
     expect(result.issues).toEqual([expect.objectContaining({ kind: 'read', path: missing })]);
   });
 
-  it('returns a typed read issue when globbing an input fails', () => {
+  it('returns a typed read issue when globbing an input fails', async () => {
     fs.globErrors.set(source, new Error('permission denied'));
 
-    const result = new IconScanner(fs, new IconParser()).scan(job, []);
+    const result = await new IconScanner(fs, new IconParser()).scan(job, []);
 
     expect(result.issues).toEqual([
       expect.objectContaining({ kind: 'read', path: source, message: expect.stringContaining('permission denied') }),

--- a/libs/ng-icons-manager/src/test/watch.spec.ts
+++ b/libs/ng-icons-manager/src/test/watch.spec.ts
@@ -190,5 +190,5 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 async function flushPromises(): Promise<void> {
-  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+  for (let index = 0; index < 25; index += 1) await Promise.resolve();
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "private": true,
   "dependencies": {
     "chokidar": "5.0.0",
-    "glob": "13.0.6",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
-      glob:
-        specifier: 13.0.6
-        version: 13.0.6
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -2837,10 +2834,6 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -3740,10 +3733,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -7855,12 +7844,6 @@ snapshots:
       path-scurry: 1.11.1
     optional: true
 
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -8728,7 +8711,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
+  minipass@7.1.3:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -9081,11 +9065,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
     optional: true
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.3.3
-      minipass: 7.1.3
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File scanning now runs asynchronously, so results are processed only after scanning finishes.
  * Improved handling of file matches to better exclude directories and return resolved paths.
  * Test utilities and watch flows were updated to wait more reliably for pending work.

* **Tests**
  * Updated scanner tests to use async/await and cover the new timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->